### PR TITLE
To test on JDK17 one needs to provide JavaScript engine

### DIFF
--- a/js/pom.xml
+++ b/js/pom.xml
@@ -98,6 +98,19 @@
         <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
+      <version>21.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js-scriptengine</artifactId>
+      <version>21.3.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Nashorn presenter for BrowserRunner -->
     <dependency>
       <groupId>org.netbeans.html</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
             <id>android</id>
             <activation>
                 <property>
-                    <name>!android.sdk.path</name>
+                    <name>android.sdk.path</name>
                 </property>
             </activation>
             <modules>


### PR DESCRIPTION
JDK17 no longer provides JavaScript engine. We need to add dependency to one such engine and then the build on JDK17 will proceed.